### PR TITLE
adding PCONV support (--use_pconv)

### DIFF
--- a/2D/argparser.py
+++ b/2D/argparser.py
@@ -53,10 +53,10 @@ parser.add_argument("--seed", type=int, default=816,
                     help="Seed for random number generation")
 parser.add_argument("--crop_dim", type=int, default=-1,
                     help="Size to crop images (square, in pixels). If -1, then no cropping.")
-parser.add_argument("--blocktime",type=int,    
+parser.add_argument("--blocktime",type=int,
                     default=settings.BLOCKTIME,
                     help="blocktime")
-parser.add_argument("--epochs", type=int, 
+parser.add_argument("--epochs", type=int,
                     default=settings.EPOCHS,
                     help="number of epochs to train")
 parser.add_argument("--learningrate",type=float,
@@ -71,21 +71,24 @@ parser.add_argument("--featuremaps",type=int,
 parser.add_argument("--keras_api",help="use keras instead of tf.keras",
                     action="store_true",
                     default=settings.USE_KERAS_API)
+parser.add_argument("--use_pconv",help="use partial convolution based padding",
+                    action="store_true",
+                    default=settings.USE_PCONV)
 parser.add_argument("--channels_first", help="use channels first data format",
                     action="store_true", default=settings.CHANNELS_FIRST)
 parser.add_argument("--print_model", help="print the model",
-                    action="store_true", 
+                    action="store_true",
                     default=settings.PRINT_MODEL)
-parser.add_argument("--use_dropout", 
+parser.add_argument("--use_dropout",
                     default=settings.USE_DROPOUT,
                     help="add spatial dropout layers 3/4",
-                    action="store_true", 
+                    action="store_true",
                     )
-parser.add_argument("--use_augmentation", 
+parser.add_argument("--use_augmentation",
                     default=settings.USE_AUGMENTATION,
                     help="use data augmentation on training images",
                     action="store_true")
-parser.add_argument("--output_pngs", 
+parser.add_argument("--output_pngs",
                     default="inference_examples",
                     help="the directory for the output prediction pngs")
 parser.add_argument("--input_filename",
@@ -108,7 +111,7 @@ parser.add_argument("-l", "--cpu_extension",
                     help="MKLDNN (CPU)-targeted custom layers. "
                     "Absolute path to a shared library with "
                     "the kernels impl.", type=str)
-parser.add_argument("-pp", "--plugin_dir", 
+parser.add_argument("-pp", "--plugin_dir",
                     help="Path to a plugin folder",
                     type=str, default=None)
 parser.add_argument("-d", "--device",
@@ -117,13 +120,13 @@ parser.add_argument("-d", "--device",
                     "will look for a suitable plugin for device "
                     "specified (CPU by default)", default="CPU",
                     type=str)
-parser.add_argument("-plot", "--plot", 
+parser.add_argument("-plot", "--plot",
                     help="Plot results",
                     default=True, action="store_true")
 parser.add_argument("-rows_per_image", "--rows_per_image",
                     help="Number of rows per plot (when -plot = True)",
                     default=4, type=int)
-parser.add_argument("-stats", "--stats", 
+parser.add_argument("-stats", "--stats",
                     help="Plot the runtime statistics",
                     default=False, action="store_true")
 

--- a/2D/libs/pconv_layer.py
+++ b/2D/libs/pconv_layer.py
@@ -1,0 +1,157 @@
+#
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+"""
+This is an implementation adapted from https://github.com/MathiasGruber/PConv-Keras
+This layer is Keras implementation of Partial Convolution based padding.
+See original contribution here: https://github.com/NVIDIA/partialconv
+"""
+
+from keras.utils import conv_utils
+from keras import backend as K
+from keras.engine import InputSpec
+from keras.layers import Conv2D
+import keras
+
+class PConv2D(Conv2D):
+    def __init__(self, *args, n_channels=3, mono=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.input_spec = [InputSpec(ndim=4)]
+
+    def build(self, input_shape):
+        """Adapted from original _Conv() layer of Keras
+        param input_shape: list of dimensions for [img]
+        """
+
+        if self.data_format == 'channels_first':
+            channel_axis = 1
+        else:
+            channel_axis = -1
+
+        if input_shape[channel_axis] is None:
+            raise ValueError('The channel dimension of the inputs should be defined. Found `None`.')
+
+        self.input_dim = input_shape[channel_axis]
+
+        # Image kernel
+        kernel_shape = self.kernel_size + (self.input_dim, self.filters)
+        self.kernel = self.add_weight(shape=kernel_shape,
+                                      initializer=self.kernel_initializer,
+                                      name='img_kernel',
+                                      regularizer=self.kernel_regularizer,
+                                      constraint=self.kernel_constraint)
+#         # Mask kernel
+        self.kernel_mask = K.ones(shape=self.kernel_size + (1, 1))
+
+        # Window size - used for normalization
+        self.window_size = self.kernel_size[0] * self.kernel_size[1]
+
+        if self.use_bias:
+            self.bias = self.add_weight(shape=(self.filters,),
+                                        initializer=self.bias_initializer,
+                                        name='bias',
+                                        regularizer=self.bias_regularizer,
+                                        constraint=self.bias_constraint)
+        else:
+            self.bias = None
+        self.built = True
+
+    def call(self, inputs, mask=None):
+        '''
+        We will be using the Keras conv2d method, and essentially we have
+        to do here is multiply the mask with the input X, before we apply the
+        convolutions. For the mask itself, we apply convolutions with all weights
+        set to 1.
+        Subsequently, we clip mask values to between 0 and 1
+        '''
+
+#        inputs[1] = torch.ones(1, 1, input.data.shape[2], input.data.shape[3]).to(input)
+        mask = K.ones(shape=(1, inputs.shape[1], inputs.shape[2], 1))
+
+        # Apply convolutions to mask
+        update_mask = K.conv2d(
+            mask, self.kernel_mask,
+            strides=self.strides,
+            padding=self.padding,
+            data_format=self.data_format,
+            dilation_rate=self.dilation_rate
+        )
+
+        # Calculate the mask ratio on each pixel in the output mask
+        mask_ratio = self.window_size / (update_mask + 1e-8)
+
+        # Clip output to be between 0 and 1
+        update_mask = K.clip(update_mask, 0, 1)
+
+        # Remove ratio values where there are holes
+        mask_ratio = mask_ratio * update_mask
+
+        # Apply convolutions to image
+        img_output = K.conv2d(
+            inputs, self.kernel,
+            strides=self.strides,
+            padding=self.padding,
+            data_format=self.data_format,
+            dilation_rate=self.dilation_rate
+        )
+
+        # Normalize image output
+        img_output = img_output * mask_ratio
+
+        # Apply bias only to the image (if chosen to do so)
+        if self.use_bias:
+            img_output = K.bias_add(
+                img_output,
+                self.bias,
+                data_format=self.data_format)
+
+        # Apply activations on the image
+        if self.activation is not None:
+            img_output = self.activation(img_output)
+
+        return img_output
+
+    def compute_output_shape(self, input_shape):
+        if self.data_format == 'channels_last':
+            space = input_shape[1:-1]
+            new_space = []
+            for i in range(len(space)):
+                new_dim = conv_utils.conv_output_length(
+                    space[i],
+                    self.kernel_size[i],
+                    padding='same',
+                    stride=self.strides[i],
+                    dilation=self.dilation_rate[i])
+                new_space.append(new_dim)
+            new_shape = (input_shape[0],) + tuple(new_space) + (self.filters,)
+            return new_shape
+        if self.data_format == 'channels_first':
+            space = input_shape[2:]
+            new_space = []
+            for i in range(len(space)):
+                new_dim = conv_utils.conv_output_length(
+                    space[i],
+                    self.kernel_size[i],
+                    padding='same',
+                    stride=self.strides[i],
+                    dilation=self.dilation_rate[i])
+                new_space.append(new_dim)
+            new_shape = (input_shape[0], self.filters) + tuple(new_space)
+            return new_shape

--- a/2D/model_pconv.py
+++ b/2D/model_pconv.py
@@ -1,0 +1,447 @@
+#
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+"""
+This module contains all of the model definition code.
+You can try custom models by modifying the code here.
+"""
+
+from argparser import args
+import os
+import time
+import shutil
+
+import tensorflow as tf  # conda install -c anaconda tensorflow
+
+if args.keras_api:
+    import keras as K
+else:
+    from tensorflow import keras as K
+
+from tensorflow.python.framework import graph_util
+from tensorflow.python.framework import graph_io
+
+from libs.pconv_layer import PConv2D
+
+class unet(object):
+    """
+    2D U-Net model class
+    """
+
+    def __init__(self, channels_first=args.channels_first,
+                 fms=args.featuremaps,
+                 output_path = args.output_path,
+                 inference_filename = args.inference_filename,
+                 batch_size = args.batch_size,
+                 blocktime = args.blocktime,
+                 num_threads = args.num_threads,
+                 learning_rate = args.learningrate,
+                 num_inter_threads = args.num_inter_threads,
+                 use_upsampling = args.use_upsampling,
+                 use_dropout = args.use_dropout,
+                 print_model = args.print_model):
+
+
+        self.channels_first = channels_first
+        if self.channels_first:
+            """
+            Use NCHW format for data
+            """
+            self.concat_axis = 1
+            self.data_format = "channels_first"
+
+        else:
+            """
+            Use NHWC format for data
+            """
+            self.concat_axis = -1
+            self.data_format = "channels_last"
+
+        self.fms = fms  # 32 or 16 depending on your memory size
+
+        self.learningrate = learning_rate
+
+        print("Data format = " + self.data_format)
+        K.backend.set_image_data_format(self.data_format)
+
+        self.output_path = output_path
+        self.inference_filename = inference_filename
+
+        self.batch_size = batch_size
+
+        self.metrics = ["accuracy", self.dice_coef, self.soft_dice_coef]
+
+        self.loss = self.dice_coef_loss
+        #self.loss = self.combined_dice_ce_loss
+
+        self.optimizer = K.optimizers.Adam(lr=self.learningrate)
+
+        self.custom_objects = {
+            "combined_dice_ce_loss": self.combined_dice_ce_loss,
+            "dice_coef_loss": self.dice_coef_loss,
+            "dice_coef": self.dice_coef,
+            "soft_dice_coef": self.soft_dice_coef}
+
+        self.blocktime = blocktime
+        self.num_threads = num_threads
+        self.num_inter_threads = num_inter_threads
+
+        self.use_upsampling = use_upsampling
+        self.use_dropout = use_dropout
+        self.print_model = print_model
+
+    def dice_coef(self, target, prediction, axis=(1, 2), smooth=0.01):
+        """
+        Sorenson Dice
+        \frac{  2 \times \left | T \right | \cap \left | P \right |}{ \left | T \right | +  \left | P \right |  }
+        where T is ground truth mask and P is the prediction mask
+        """
+        prediction = K.backend.round(prediction)  # Round to 0 or 1
+
+        intersection = tf.reduce_sum(target * prediction, axis=axis)
+        union = tf.reduce_sum(target + prediction, axis=axis)
+        numerator = tf.constant(2.) * intersection + smooth
+        denominator = union + smooth
+        coef = numerator / denominator
+
+        return tf.reduce_mean(coef)
+
+    def soft_dice_coef(self, target, prediction, axis=(1, 2), smooth=0.01):
+        """
+        Sorenson (Soft) Dice  - Don't round the predictions
+        \frac{  2 \times \left | T \right | \cap \left | P \right |}{ \left | T \right | +  \left | P \right |  }
+        where T is ground truth mask and P is the prediction mask
+        """
+
+        intersection = tf.reduce_sum(target * prediction, axis=axis)
+        union = tf.reduce_sum(target + prediction, axis=axis)
+        numerator = tf.constant(2.) * intersection + smooth
+        denominator = union + smooth
+        coef = numerator / denominator
+
+        return tf.reduce_mean(coef)
+
+    def dice_coef_loss(self, target, prediction, axis=(1, 2), smooth=1.0):
+        """
+        Sorenson (Soft) Dice loss
+        Using -log(Dice) as the loss since it is better behaved.
+        Also, the log allows avoidance of the division which
+        can help prevent underflow when the numbers are very small.
+        """
+        intersection = tf.reduce_sum(prediction * target, axis=axis)
+        p = tf.reduce_sum(prediction, axis=axis)
+        t = tf.reduce_sum(target, axis=axis)
+        numerator = tf.reduce_mean(intersection + smooth)
+        denominator = tf.reduce_mean(t + p + smooth)
+        dice_loss = -tf.log(2.*numerator) + tf.log(denominator)
+
+        return dice_loss
+
+
+    def combined_dice_ce_loss(self, target, prediction, axis=(1, 2), smooth=1.0,
+                              weight=args.weight_dice_loss):
+        """
+        Combined Dice and Binary Cross Entropy Loss
+        """
+        return weight*self.dice_coef_loss(target, prediction, axis, smooth) + \
+            (1-weight)*K.losses.binary_crossentropy(target, prediction)
+
+
+    def unet_model(self, imgs_shape, msks_shape,
+                   dropout=0.2,
+                   final=False):
+        """
+        U-Net Model
+        ===========
+        Based on https://arxiv.org/abs/1505.04597
+        The default uses UpSampling2D (bilinear interpolation) in
+        the decoder path. The alternative is to use Transposed
+        Convolution.
+        """
+
+        if not final:
+            if self.use_upsampling:
+                print("Using UpSampling2D")
+            else:
+                print("Using Transposed Deconvolution")
+
+        num_chan_in = imgs_shape[self.concat_axis]
+        num_chan_out = msks_shape[self.concat_axis]
+
+        # You can make the network work on variable input height and width
+        # if you pass None as the height and width
+        if self.channels_first:
+             self.input_shape = [num_chan_in, None, None]
+        else:
+             self.input_shape = [None, None, num_chan_in]
+
+        self.input_shape = imgs_shape[1:]
+
+        self.num_input_channels = num_chan_in
+
+        inputs = K.layers.Input(self.input_shape, name="MRImages")
+
+        # Convolution parameters
+        params = dict(kernel_size=(3, 3), activation="relu",
+                      padding="same",
+                      kernel_initializer="he_uniform")
+
+        # Transposed convolution parameters
+        params_trans = dict(kernel_size=(2, 2), strides=(2, 2),
+                            padding="same")
+
+        encodeA = PConv2D(name="encodeAa", filters=self.fms, **params)(inputs)
+        encodeA = PConv2D(name="encodeAb", filters=self.fms, **params)(encodeA)
+        poolA = K.layers.MaxPooling2D(name="poolA", pool_size=(2, 2))(encodeA)
+
+        encodeB = PConv2D(name="encodeBa", filters=self.fms*2, **params)(poolA)
+        encodeB = PConv2D(
+            name="encodeBb", filters=self.fms*2, **params)(encodeB)
+        poolB = K.layers.MaxPooling2D(name="poolB", pool_size=(2, 2))(encodeB)
+
+        encodeC = PConv2D(name="encodeCa", filters=self.fms*4, **params)(poolB)
+        if self.use_dropout:
+            encodeC = K.layers.SpatialDropout2D(dropout)(encodeC)
+        encodeC = PConv2D(
+            name="encodeCb", filters=self.fms*4, **params)(encodeC)
+
+        poolC = K.layers.MaxPooling2D(name="poolC", pool_size=(2, 2))(encodeC)
+
+
+        encodeD = PConv2D(name="encodeDa", filters=self.fms*8, **params)(poolC)
+        if self.use_dropout:
+            encodeD = K.layers.SpatialDropout2D(dropout)(encodeD)
+        encodeD = PConv2D(
+            name="encodeDb", filters=self.fms*8, **params)(encodeD)
+
+        poolD = K.layers.MaxPooling2D(name="poolD", pool_size=(2, 2))(encodeD)
+
+        encodeE = PConv2D(name="encodeEa", filters=self.fms*16, **params)(poolD)
+        encodeE = PConv2D(
+            name="encodeEb", filters=self.fms*16, **params)(encodeE)
+
+        if self.use_upsampling:
+            up = K.layers.UpSampling2D(name="upE", size=(2, 2),
+                                       interpolation="bilinear")(encodeE)
+        else:
+            up = K.layers.Conv2DTranspose(name="transconvE", filters=self.fms*8,
+                                          **params_trans)(encodeE)
+        concatD = K.layers.concatenate(
+            [up, encodeD], axis=self.concat_axis, name="concatD")
+
+        decodeC = PConv2D(
+            name="decodeCa", filters=self.fms*8, **params)(concatD)
+        decodeC = PConv2D(
+            name="decodeCb", filters=self.fms*8, **params)(decodeC)
+
+        if self.use_upsampling:
+            up = K.layers.UpSampling2D(name="upC", size=(2, 2),
+                                       interpolation="bilinear")(decodeC)
+        else:
+            up = K.layers.Conv2DTranspose(name="transconvC", filters=self.fms*4,
+                                          **params_trans)(decodeC)
+        concatC = K.layers.concatenate(
+            [up, encodeC], axis=self.concat_axis, name="concatC")
+
+        decodeB = PConv2D(
+            name="decodeBa", filters=self.fms*4, **params)(concatC)
+        decodeB = PConv2D(
+            name="decodeBb", filters=self.fms*4, **params)(decodeB)
+
+        if self.use_upsampling:
+            up = K.layers.UpSampling2D(name="upB", size=(2, 2),
+                                       interpolation="bilinear")(decodeB)
+        else:
+            up = K.layers.Conv2DTranspose(name="transconvB", filters=self.fms*2,
+                                          **params_trans)(decodeB)
+        concatB = K.layers.concatenate(
+            [up, encodeB], axis=self.concat_axis, name="concatB")
+
+        decodeA = PConv2D(
+            name="decodeAa", filters=self.fms*2, **params)(concatB)
+        decodeA = PConv2D(
+            name="decodeAb", filters=self.fms*2, **params)(decodeA)
+
+        if self.use_upsampling:
+            up = K.layers.UpSampling2D(name="upA", size=(2, 2),
+                                       interpolation="bilinear")(decodeA)
+        else:
+            up = K.layers.Conv2DTranspose(name="transconvA", filters=self.fms,
+                                          **params_trans)(decodeA)
+        concatA = K.layers.concatenate(
+            [up, encodeA], axis=self.concat_axis, name="concatA")
+
+        convOut = PConv2D(name="convOuta", filters=self.fms, **params)(concatA)
+        convOut = PConv2D(name="convOutb", filters=self.fms, **params)(convOut)
+
+        prediction = K.layers.Conv2D(name="PredictionMask",
+                                     filters=num_chan_out, kernel_size=(1, 1),
+                                     activation="sigmoid")(convOut)
+
+        model = K.models.Model(inputs=[inputs], outputs=[prediction])
+
+        optimizer = self.optimizer
+
+        if final:
+            model.trainable = False
+        else:
+
+            model.compile(optimizer=optimizer,
+                          loss=self.loss,
+                          metrics=self.metrics)
+
+            if self.print_model:
+                model.summary()
+
+        return model
+
+
+    def get_callbacks(self):
+        """
+        Define any callbacks for the training
+        """
+
+        model_filename = os.path.join(self.output_path, self.inference_filename)
+
+        print("Writing model to '{}'".format(model_filename))
+
+        # Save model whenever we get better validation loss
+        model_checkpoint = K.callbacks.ModelCheckpoint(model_filename,
+                                                       verbose=1,
+                                                       monitor="val_loss",
+                                                       save_best_only=True)
+
+        directoryName = "unet_block{}_inter{}_intra{}".format(self.blocktime,
+                                                              self.num_threads,
+                                                              self.num_inter_threads)
+
+        # Tensorboard callbacks
+        if (args.use_upsampling):
+            tensorboard_filename = os.path.join(self.output_path,
+                                                "keras_tensorboard_upsampling"
+                                                "_batch{}/{}".format(
+                                                    self.batch_size, directoryName))
+        else:
+            tensorboard_filename = os.path.join(self.output_path,
+                                                "keras_tensorboard_transposed"
+                                                "_batch{}/{}".format(
+                                                    self.batch_size, directoryName))
+
+        tensorboard_checkpoint = K.callbacks.TensorBoard(
+            log_dir=tensorboard_filename,
+            write_graph=True, write_images=True)
+
+        return model_filename, [model_checkpoint, tensorboard_checkpoint]
+
+
+    def evaluate_model(self, model_filename, imgs_validation, msks_validation):
+        """
+        Evaluate the best model on the validation dataset
+        """
+
+        model = K.models.load_model(model_filename, custom_objects=self.custom_objects)
+
+        K.backend.set_learning_phase(0)
+        start_inference = time.time()
+        print("Evaluating model on test dataset. Please wait...")
+        metrics = model.evaluate(
+            imgs_validation,
+            msks_validation,
+            batch_size=self.batch_size,
+            verbose=1)
+        elapsed_time = time.time() - start_inference
+        print("{} images in {:.2f} seconds => {:.3f} images per "
+              "second inference".format(
+                  imgs_validation.shape[0], elapsed_time,
+                  imgs_validation.shape[0] / elapsed_time))
+
+        for idx, metric in enumerate(metrics):
+            print("Test dataset {} = {:.4f}".format(model.metrics_names[idx], metric))
+
+
+    def create_model(self, imgs_shape, msks_shape,
+                   dropout=0.2,
+                   final=False):
+        """
+        If you have other models, you can try them here
+        """
+        return self.unet_model(imgs_shape, msks_shape,
+                          dropout=dropout,
+                          final=final)
+
+    def load_model(self, model_filename):
+        """
+        Load a model from Keras file
+        """
+
+        return K.models.load_model(model_filename, custom_objects=self.custom_objects)
+
+
+    def save_frozen_model(self, model_filename, input_shape):
+        """
+        Save frozen TensorFlow formatted model protobuf
+        """
+        model = self.load_model(model_filename)
+
+        # Change filename to protobuf extension
+        base = os.path.basename(model_filename)
+        output_model = os.path.splitext(base)[0] + ".pb"
+
+        # Set Keras to inference
+        K.backend._LEARNING_PHASE = tf.constant(0)
+        K.backend.set_learning_phase(False)
+        K.backend.set_learning_phase(0)
+        K.backend.set_image_data_format("channels_last")
+
+        num_output = len(model.outputs)
+        predictions = [None] * num_output
+        prediction_node_names = [None] * num_output
+
+        for i in range(num_output):
+            prediction_node_names[i] = "output_node" + str(i)
+            predictions[i] = tf.identity(model.outputs[i],
+                    name=prediction_node_names[i])
+
+        sess = K.backend.get_session()
+
+        constant_graph = graph_util.convert_variables_to_constants(sess,
+                         sess.graph.as_graph_def(), prediction_node_names)
+        infer_graph = graph_util.remove_training_nodes(constant_graph)
+
+        # Write protobuf of frozen model
+        frozen_dir = "./frozen_model/"
+        shutil.rmtree(frozen_dir, ignore_errors=True) # Remove existing directory
+        graph_io.write_graph(infer_graph, frozen_dir, output_model, as_text=False)
+
+        pb_filename = os.path.join(frozen_dir, output_model)
+        print("Frozen TensorFlow model written to: {}".format(pb_filename))
+        print("Convert this to OpenVINO by running:\n")
+        print("source /opt/intel/openvino/bin/setupvars.sh")
+        print("python $INTEL_OPENVINO_DIR/deployment_tools/model_optimizer/mo_tf.py \\")
+        print("       --input_model {} \\".format(pb_filename))
+
+        shape_string = "[1"
+        for idx in range(len(input_shape[1:])):
+            shape_string += ",{}".format(input_shape[idx+1])
+        shape_string += "]"
+
+        print("       --input_shape {} \\".format(shape_string))
+        print("       --output_dir openvino_models/FP32/ \\")
+        print("       --data_type FP32\n\n")

--- a/2D/model_pconv.py
+++ b/2D/model_pconv.py
@@ -390,7 +390,9 @@ class unet(object):
         """
         Load a model from Keras file
         """
-
+        if args.use_pconv:
+            self.custom_objects.update( {'PConv2D' : PConv2D} )
+            
         return K.models.load_model(model_filename, custom_objects=self.custom_objects)
 
 

--- a/2D/plot_inference_examples.py
+++ b/2D/plot_inference_examples.py
@@ -21,7 +21,6 @@
 """
 Takes a trained model and performs inference on a few validation examples.
 """
-from model import unet
 import os
 
 import numpy as np
@@ -149,6 +148,10 @@ if __name__ == "__main__":
     files_testing = df["testing_input_files"]
 
     # Load model
+    if args.use_pconv:
+        from model_pconv import unet
+    else:
+        from model import unet    
     unet_model = unet()
     model = unet_model.load_model(model_filename)
 

--- a/2D/plot_inference_examples.py
+++ b/2D/plot_inference_examples.py
@@ -47,7 +47,9 @@ parser.add_argument("--output_path", default=settings.OUT_PATH,
                     help="the folder to save the model and checkpoints")
 parser.add_argument("--inference_filename", default=settings.INFERENCE_FILENAME,
                     help="the Keras inference model filename")
-
+parser.add_argument("--use_pconv",help="use partial convolution based padding",
+                    action="store_true",
+                    default=settings.USE_PCONV)
 parser.add_argument("--output_pngs", default="inference_examples",
                     help="the directory for the output prediction pngs")
 

--- a/2D/settings.py
+++ b/2D/settings.py
@@ -68,4 +68,4 @@ USE_KERAS_API = True   # If true, then use Keras API. Otherwise, use tf.keras
 USE_UPSAMPLING = False
 USE_AUGMENTATION = True  # Use data augmentation during training
 USE_DROPOUT = False  # Use spatial dropout in model
-USE_PCONV = True   # If True, Partial Convolution based padding will be used. See https://arxiv.org/pdf/1811.11718.pdf
+USE_PCONV = False   # If True, Partial Convolution based padding will be used. See https://arxiv.org/pdf/1811.11718.pdf

--- a/2D/settings.py
+++ b/2D/settings.py
@@ -68,3 +68,4 @@ USE_KERAS_API = True   # If true, then use Keras API. Otherwise, use tf.keras
 USE_UPSAMPLING = False
 USE_AUGMENTATION = True  # Use data augmentation during training
 USE_DROPOUT = False  # Use spatial dropout in model
+USE_PCONV = True   # If True, Partial Convolution based padding will be used. See https://arxiv.org/pdf/1811.11718.pdf

--- a/2D/train.py
+++ b/2D/train.py
@@ -30,7 +30,6 @@ import os
 import tensorflow as tf  # conda install -c anaconda tensorflow
 import settings   # Use the custom settings.py file for default parameters
 
-from model import unet
 from data import load_data
 
 import numpy as np
@@ -99,6 +98,10 @@ def train_and_predict(data_path, data_filename, batch_size, n_epoch):
     """
     Step 2: Define the model
     """
+    if args.use_pconv:
+        from model_pconv import unet
+    else:
+        from model import unet
 
     unet_model = unet()
     model = unet_model.create_model(imgs_train.shape, msks_train.shape)


### PR DESCRIPTION
Adding support for Partial Convolution based padding. 
This is an implementation adapted from https://github.com/MathiasGruber/PConv-Keras
This layer is Keras implementation of Partial Convolution based padding.
See original contribution here: https://github.com/NVIDIA/partialconv

- Added a new file `libs/pconv_layer.py`, this is a keras implementation from the original contribution.
- Added a new file `model_pconv.py`: This replaces all `K.layers.Conv2D` to `PCONV2D`.
- Added a new flag `--use_pconv`, this will load the model defined in `model_pconv.py` which uses layer  'libs/pconv_layer.py`
- The end-user can either edit the `settings.py` file or pass the argument `--use_pconv` to the `train.py` script